### PR TITLE
Feat: add incrBy operator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -220,6 +220,9 @@ export declare class QueryOperator extends Query {
 
   constructor(conn: Connection | Pool, opt?: QueryOperatorBaseOptions);
 
+  /**
+   * @deprecated will deprecated on v1.0+ version
+   */
   buildSql(operator: OperatorType): { sql: string, values: any[] };
 
   exec(): Promise<QueryResult>;
@@ -231,6 +234,13 @@ export declare class QueryOperator extends Query {
   find<T>(): Promise<T>;
 
   count(): Promise<number>;
+
+  /**
+   * increment a column value
+   * @param attr 
+   * @param increment default is 1
+   */
+  incrBy(attr: string, increment?: string | number | ((number: number) => number)): Promise<MySQLQueryResult>;
 
   delete(id?: number, index_field_name?: string): Promise<MySQLQueryResult>;
 
@@ -249,6 +259,8 @@ export declare class QueryOperator extends Query {
   upsertRow(row: any, condition: QueryCondition): Promise<MySQLQueryResult>;
 
   upsertRow<T extends Object>(row: T, ...conditions: WhereItem[]): Promise<MySQLQueryResult>;
+
+  notExec(): this;
 }
 
 export type TableInfoColumn = 'TABLE_CATALOG' | 'TABLE_SCHEMA' | 'TABLE_NAME' | 'COLUMN_NAME' | 'ORDINAL_POSITION' |

--- a/src/builder.js
+++ b/src/builder.js
@@ -92,6 +92,26 @@ class Builder {
         sql = tmp.join(' ');
         break;
       }
+      case 'incrBy': {
+        emit(tmp, `UPDATE ${this._buildTables(options.tables)}`);
+        let key = this._buildFieldKey(options.attrs[0]);
+        emit(tmp, `SET ${key} = ${key} + ?`);
+        if (is.string(options.increment)) {
+          this.values.push(parseInt(options.increment, 10));
+        } else if (is.func(options.increment)) {
+          this.values.push(options.increment());
+        } else if (is.number(options.increment)) {
+          this.values.push(options.increment);
+        } else {
+          throw new Error('Invalid increment value');
+        }
+        if (!options.conditions.length) {
+          throw new Error('At least one condition is required for update operation');
+        }
+        emit(tmp, this._buildCondition(options.conditions));
+        sql = tmp.join(' ');
+        break;
+      }
       case 'delete': {
         emit(tmp, `DELETE FROM ${this._buildTables(options.tables)}`);
         if (!options.conditions.length) {

--- a/src/operator.js
+++ b/src/operator.js
@@ -27,8 +27,14 @@ class QueryOperator extends Query {
     }
   }
 
+  /**
+   * @deprecated use QueryOperator.notExec() instead
+   * @param {*} operator 
+   * @returns 
+   */
   buildSql(operator) {
     this.options.operator = operator;
+    this.options.notExec = true;
     return new Builder(this.options);
   }
 
@@ -39,6 +45,9 @@ class QueryOperator extends Query {
   }
 
   async exec() {
+    if (this.options.notExec === true) {
+      return new Builder(this.options);
+    }
     if (!this.options.operator) {
       throw new Error('Invalid operator: ' + this.options.operator);
     }
@@ -173,6 +182,11 @@ class QueryOperator extends Query {
       return await q.update(data);
     }
     return await query.insert(data);
+  }
+
+  notExec() {
+    this.options.notExec = true;
+    return this;
   }
 }
 

--- a/src/operator.js
+++ b/src/operator.js
@@ -134,6 +134,19 @@ class QueryOperator extends Query {
     return await this.exec();
   }
 
+  /**
+   * increment a column value
+   * @param {string} attr 
+   * @param {string | number, callback?: Callback} increment 
+   * @returns 
+   */
+  async incrBy(attr, increment = 1) {
+    this.options.attrs = [attr];
+    this.options.operator = 'incrBy';
+    this.options.increment = increment;
+    return await this.exec();
+  }
+
   async delete(id, index_field_name = 'id') {
     if (id) {
       this.where(index_field_name, id);

--- a/src/query.js
+++ b/src/query.js
@@ -174,6 +174,7 @@ class Query extends QueryCondition {
       transaction: false,
       keys: null,
       explain: false,
+      notExec: false,
     };
     this.alias = alias || null;
   }

--- a/tests/builder.tests.js
+++ b/tests/builder.tests.js
@@ -258,7 +258,7 @@ describe('builder test case', () => {
     };
     expect(() => {
       (new Builder(options)).sql;
-    }).to.throw('Invalid operator: invalid');
+    }).to.throw('Unsupported \'invalid\' operation.');
   });
 
   it('build manage sql', () => {

--- a/tests/query.tests.js
+++ b/tests/query.tests.js
@@ -288,4 +288,38 @@ describe('query test case', () => {
     const builder = new Builder(query.options);
     expect(builder.sql).to.be.equal('SELECT * FROM `users` WHERE `name` LIKE ?');
   });
+
+  it('incrBy query should be ok', async () => {
+    const handle = new QueryHandler();
+    let res = await handle.table('test').where('id', 1)
+      .notExec()
+      .incrBy('number');
+
+    expect(res.sql).to.be.equal('UPDATE `test` SET `number` = `number` + ? WHERE `id` = ?');
+    expect(JSON.stringify(res.values)).to.be.equal('[1,1]');
+
+    res = await handle.table('test').where('id', 1)
+      .notExec()
+      .incrBy('number', '2');
+
+    expect(res.sql).to.be.equal('UPDATE `test` SET `number` = `number` + ? WHERE `id` = ?');
+    expect(JSON.stringify(res.values)).to.be.equal('[2,1]');
+
+    let data = {
+      status: 'success',
+      value: 200,
+    };
+    res = await handle.table('test').where('id', 1)
+      .notExec()
+      .incrBy('number', () => {
+        if (data.status === 'success') {
+          return 0;
+        }
+        // error times increase
+        return 1;
+      });
+
+    expect(res.sql).to.be.equal('UPDATE `test` SET `number` = `number` + ? WHERE `id` = ?');
+    expect(JSON.stringify(res.values)).to.be.equal('[0,1]');
+  });
 });


### PR DESCRIPTION

This pull request introduces several enhancements and new features to the query builder, specifically adding support for increment operations and improving the handling of query execution. The most important changes include adding the `incrBy` operation, deprecating the `buildSql` method, and updating the test cases to cover the new functionality.

Enhancements to query builder:

* [`src/builder.js`](diffhunk://#diff-862eedfba83ac0f638b3c5abb5a60d3548bc5b5ab971f9cb12b79507777f86ddR95-R114): Added support for the `incrBy` operation, which allows incrementing a column value by a specified amount. This includes validation for the increment value and ensuring at least one condition is provided for the update operation.

Deprecation and new methods:

* [`src/operator.js`](diffhunk://#diff-d64c2c4916bc286ec1e1f1905f734eda48c07a80b0a6ccd8c4106195d34ed95bR30-R37): Deprecated the `buildSql` method in favor of the `notExec` method, which sets the `notExec` option to true. Added the `incrBy` method to increment a column value and the `notExec` method to mark a query as not executable immediately. [[1]](diffhunk://#diff-d64c2c4916bc286ec1e1f1905f734eda48c07a80b0a6ccd8c4106195d34ed95bR30-R37) [[2]](diffhunk://#diff-d64c2c4916bc286ec1e1f1905f734eda48c07a80b0a6ccd8c4106195d34ed95bR48-R50) [[3]](diffhunk://#diff-d64c2c4916bc286ec1e1f1905f734eda48c07a80b0a6ccd8c4106195d34ed95bR146-R158) [[4]](diffhunk://#diff-d64c2c4916bc286ec1e1f1905f734eda48c07a80b0a6ccd8c4106195d34ed95bR186-R190)

Configuration updates:

* [`src/query.js`](diffhunk://#diff-b2645dc16182d4a459334bbc48aaf52084412ac325940cc19caee52718a59186R177): Added the `notExec` option to the query options to support the new `notExec` method.

Test case updates:

* [`tests/query.tests.js`](diffhunk://#diff-5f5bdcd9d9695f21c680ff6083cf84e7420d69e86eb799ca1e028e87a022198fR291-R324): Added test cases for the `incrBy` operation to ensure it works correctly with different increment values, including numbers, strings, and callback functions.