### PR TITLE
fix(builder): enhance createForeignKey to support onCreateTable option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -640,9 +640,20 @@ export declare class MigrationInterface {
   createForeignKey(table: string, options: {
     foreignKey?: string,
     columnName: string,
-    reference: {
-      tableName: string,
-      columnName: string,
+    references?: {
+      table: string,
+      column: string,
+      onDelete?: CascadeType,
+      onUpdate?: CascadeType,
+    },
+    /** @deprecated Use `references` instead */
+    reference?: {
+      table?: string,
+      column?: string,
+      /** @deprecated Use `table` instead */
+      tableName?: string,
+      /** @deprecated Use `column` instead */
+      columnName?: string,
       onDelete?: CascadeType,
       onUpdate?: CascadeType,
     }

--- a/src/builder.js
+++ b/src/builder.js
@@ -583,7 +583,16 @@ class ManageSQLBuilder extends Builder {
   }
 
   createForeignKey(options, onCreateTable = false) {
+    if (options.reference && !options.references) {
+      options.references = options.reference;
+    }
     if (options.references) {
+      if (options.references.tableName && !options.references.table) {
+        options.references.table = options.references.tableName;
+      }
+      if (options.references.columnName && !options.references.column) {
+        options.references.column = options.references.columnName;
+      }
       options.references.onDelete = options.references.onDelete ? options.references.onDelete.toUpperCase() : 'NO ACTION';
       options.references.onUpdate = options.references.onUpdate ? options.references.onUpdate.toUpperCase() : 'NO ACTION';
     }

--- a/src/builder.js
+++ b/src/builder.js
@@ -673,6 +673,12 @@ class ManageSQLBuilder extends Builder {
         column.references = column.reference;
       }
       if (column.references) {
+        if (column.references.tableName && !column.references.table) {
+          column.references.table = column.references.tableName;
+        }
+        if (column.references.columnName && !column.references.column) {
+          column.references.column = column.references.columnName;
+        }
         column.references.onDelete = column.references.onDelete ? column.references.onDelete.toUpperCase() : 'NO ACTION';
         column.references.onUpdate = column.references.onUpdate ? column.references.onUpdate.toUpperCase() : 'NO ACTION';
 

--- a/src/migration.js
+++ b/src/migration.js
@@ -227,13 +227,22 @@ function _initMigration(file, queries = {}) {
 
   Object.defineProperty(migration, 'createForeignKey', {
     value: function (table, options = {}) {
+      const refs = options.references || options.reference;
+      if (refs) {
+        if (refs.tableName && !refs.table) {
+          refs.table = refs.tableName;
+        }
+        if (refs.columnName && !refs.column) {
+          refs.column = refs.columnName;
+        }
+      }
       _assign(options, {
         operator: 'create',
         target: 'foreignKey',
         name: options.foreignKey ? options.foreignKey : 'fk_' + table + '_' + options.columnName,
         table: table,
         column: options.columnName,
-        references: options.references || options.reference  // 兼容性处理
+        references: refs
       });
       const builder = new ManageSQLBuilder(options);
       queries[file].push({ sql: builder.sql, values: builder.values });

--- a/tests/builder.tests.js
+++ b/tests/builder.tests.js
@@ -916,6 +916,28 @@ describe('builder test case', () => {
       expect(sql).to.be.equal('ALTER TABLE `test_table` DROP FOREIGN KEY `fk_test`');
     });
 
+    it('should handle createForeignKey with deprecated reference (singular) option', () => {
+      const builder = new ManageSQLBuilder({
+        operator: 'create',
+        target: 'foreignKey',
+        name: 'fk_orders_user_id',
+        table: 'orders',
+        column: 'user_id',
+        reference: {
+          tableName: 'users',
+          columnName: 'id',
+          onDelete: 'CASCADE',
+          onUpdate: 'RESTRICT'
+        }
+      });
+      const sql = builder.sql;
+      expect(sql).to.include('ALTER TABLE `orders`');
+      expect(sql).to.include('FOREIGN KEY (`user_id`)');
+      expect(sql).to.include('REFERENCES `users` (`id`)');
+      expect(sql).to.include('ON DELETE CASCADE');
+      expect(sql).to.include('ON UPDATE RESTRICT');
+    });
+
     it('should handle createColumns with uniqIndex', () => {
       const options = {
         operator: 'create',

--- a/tests/migration.tests.js
+++ b/tests/migration.tests.js
@@ -252,9 +252,9 @@ describe('migration test case', () => {
 
       migrationObj.createForeignKey('orders', {
         columnName: 'user_id',
-        reference: {
-          tableName: 'users',
-          columnName: 'id',
+        references: {
+          table: 'users',
+          column: 'id',
           onDelete: 'CASCADE',
           onUpdate: 'RESTRICT'
         }
@@ -275,9 +275,9 @@ describe('migration test case', () => {
       migrationObj.createForeignKey('orders', {
         foreignKey: 'fk_custom_key',
         columnName: 'user_id',
-        reference: {
-          tableName: 'users',
-          columnName: 'id'
+        references: {
+          table: 'users',
+          column: 'id'
         }
       });
 

--- a/tests/migration.tests.js
+++ b/tests/migration.tests.js
@@ -284,6 +284,31 @@ describe('migration test case', () => {
       expect(queries[file].length).to.be.equal(1);
       expect(queries[file][0].sql).to.include('fk_custom_key');
     });
+
+    it('should accept deprecated reference/tableName/columnName format', () => {
+      const queries = {};
+      const file = 'test_migration.js';
+      queries[file] = [];
+      const migrationObj = _initMigration(file, queries);
+
+      migrationObj.createForeignKey('orders', {
+        columnName: 'user_id',
+        reference: {
+          tableName: 'users',
+          columnName: 'id',
+          onDelete: 'CASCADE',
+          onUpdate: 'RESTRICT'
+        }
+      });
+
+      expect(queries[file].length).to.be.equal(1);
+      expect(queries[file][0].sql).to.include('FOREIGN KEY');
+      expect(queries[file][0].sql).to.include('fk_orders_user_id');
+      expect(queries[file][0].sql).to.include('`users`');
+      expect(queries[file][0].sql).to.include('`id`');
+      expect(queries[file][0].sql).to.include('CASCADE');
+      expect(queries[file][0].sql).to.include('RESTRICT');
+    });
   });
 
   describe('dropTable method', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches SQL generation for foreign keys and option validation/normalization, so regressions could break migrations or produce invalid DDL for some input shapes despite added test coverage.
> 
> **Overview**
> Adds an `onCreateTable` mode to `ManageSQLBuilder.createForeignKey` so foreign keys can be rendered inline as `CONSTRAINT ...` clauses during `CREATE TABLE`, while keeping the existing `ALTER TABLE ... ADD CONSTRAINT` path for standalone operations.
> 
> Standardizes foreign-key option naming to `table`/`column` under `references` (and `table`/`column` for the target as well), with backward-compatible support for deprecated `reference` and `tableName`/`columnName` inputs across the builder, migrations API, and TypeScript definitions; tests are updated/added to cover both modern and legacy formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f95eab8fcca5296d915205570532fa124213bc67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->