### PR TITLE
feat(migration): add renameTable method for table renaming functionality

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -688,9 +688,26 @@ export declare class MigrationInterface {
    */
   dropForeignKey(tableName: string, foreign_key: string): void;
 
+  /**
+   * insert data into table
+   * @param table 
+   * @param data 
+   */
   insertData(table: string, data: any[]): void;
 
+  /**
+   * execute raw sql
+   * @param sql 
+   * @param values 
+   */
   raw(sql: string, values: any[]): void;
+
+  /**
+   * rename table
+   * @param oldTableName 
+   * @param newTableName 
+   */
+  renameTable(oldTableName: string, newTableName: string): void;
 }
 
 export type MigrateAction = 'up' | 'down' | 'UP' | 'DOWN';

--- a/src/builder.js
+++ b/src/builder.js
@@ -523,6 +523,14 @@ class ManageSQLBuilder extends Builder {
     }
   }
 
+  renameTable(options) {
+    _validate(options, {
+      oldName: 'required|string',
+      newName: 'required|string',
+    });
+    return _render('RENAME TABLE `${oldName}` TO `${newName}`', options);
+  }
+
   /**
    * @param {import('./migration').ManageBuilderOptions} options 
    */

--- a/src/migration.js
+++ b/src/migration.js
@@ -325,6 +325,18 @@ function _initMigration(file, queries = {}) {
     }, ...baseAttr
   });
 
+  Object.defineProperty(migration, 'renameTable', {
+    value: function (oldTableName, newTableName) {
+      const builder = new ManageSQLBuilder({
+        operator: 'rename',
+        target: 'table',
+        oldName: oldTableName,
+        newName: newTableName
+      });
+      queries[file].push({ sql: builder.sql, values: builder.values });
+    }, ...baseAttr
+  });
+
   return migration;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new schema-altering migration operation (`RENAME TABLE`), which could impact production data if used incorrectly, but the change is small and isolated to migration SQL generation.
> 
> **Overview**
> Adds a new migration API `renameTable(oldTableName, newTableName)` and wires it through the migration DSL to emit a `RENAME TABLE ... TO ...` statement.
> 
> Updates the TypeScript declarations and extends `ManageSQLBuilder` with validation/rendering for the new rename operation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fe4d4a894d44d982af647e1e89d014e7c6f1579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->