### PR TITLE
feat(migration, builder): add changeColumn method for modifying exist…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -708,6 +708,16 @@ export declare class MigrationInterface {
    * @param newTableName 
    */
   renameTable(oldTableName: string, newTableName: string): void;
+
+  /**
+   * change column
+   * @param tableName 
+   * @param columnName 
+   * @param options 
+   */
+  changeColumn(tableName: string, columnName: string, options: {
+    type: FieldType,
+  } & CreateColumnOptions): void;
 }
 
 export type MigrateAction = 'up' | 'down' | 'UP' | 'DOWN';

--- a/src/builder.js
+++ b/src/builder.js
@@ -523,6 +523,18 @@ class ManageSQLBuilder extends Builder {
     }
   }
 
+  changeColumn(options) {
+    _validate(options, {
+      tableName: 'required|string',
+      columnName: 'required|string',
+    });
+    const columnOptions = {
+      ...options.options,
+      name: options.columnName,
+    };
+    return _render('ALTER TABLE `${tableName}` MODIFY COLUMN ' + this.renderSingleColumn(columnOptions), { tableName: options.tableName });
+  }
+
   renameTable(options) {
     _validate(options, {
       oldName: 'required|string',

--- a/src/migration.js
+++ b/src/migration.js
@@ -337,6 +337,19 @@ function _initMigration(file, queries = {}) {
     }, ...baseAttr
   });
 
+  Object.defineProperty(migration, 'changeColumn', {
+    value: function (tableName, columnName, options) {
+      const builder = new ManageSQLBuilder({
+        operator: 'change',
+        target: 'column',
+        tableName,
+        columnName,
+        options
+      });
+      queries[file].push({ sql: builder.sql, values: builder.values });
+    }, ...baseAttr
+  });
+
   return migration;
 }
 


### PR DESCRIPTION
…ing columns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new migration operation that emits `ALTER TABLE ... MODIFY COLUMN`, which can alter live schema and potentially cause data/type incompatibilities if used incorrectly.
> 
> **Overview**
> Adds a new migration API `changeColumn(tableName, columnName, options)` (and TypeScript typings) to modify existing table columns.
> 
> Implements SQL generation in `ManageSQLBuilder.changeColumn` to render `ALTER TABLE ... MODIFY COLUMN` using existing column rendering/validation, and wires it into `migration` so migrations enqueue the generated query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93aec43680e5f40bf793ea806e8e65ae54cd73ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->